### PR TITLE
Set 'commentstring' option

### DIFF
--- a/ftdetect/gitignore.vim
+++ b/ftdetect/gitignore.vim
@@ -1,5 +1,5 @@
 " File:         gitignore.vim
-" Description:  Play! framework plugin for Vim
+" Description:  .gitignore plugin for Vim
 " Author:       Roman Dolgushin <rd@roman-dolgushin.ru>
 " URL:          https://github.com/rdolgushin/gitignore.vim
 

--- a/snippets/gitignore/Clojure.snippet
+++ b/snippets/gitignore/Clojure.snippet
@@ -1,1 +1,1 @@
-Leiningen.gitignore
+Leiningen.snippet

--- a/syntax/gitignore.vim
+++ b/syntax/gitignore.vim
@@ -3,15 +3,15 @@
 " Maintainer:	Roman Dolgushin <rd@roman-dolgushin.ru>
 " URL:		http://github.com/rdolgushin/gitignore.vim
 
-if exists("b:current_syntax")
+if exists('b:current_syntax')
   finish
 endif
 
-if !exists("main_syntax")
+if !exists('main_syntax')
   let main_syntax = 'conf'
 endif
 
 runtime! syntax/conf.vim
 unlet b:current_syntax
 
-let b:current_syntax = "gitignore"
+let b:current_syntax = 'gitignore'

--- a/syntax/gitignore.vim
+++ b/syntax/gitignore.vim
@@ -15,3 +15,5 @@ runtime! syntax/conf.vim
 unlet b:current_syntax
 
 let b:current_syntax = 'gitignore'
+
+setlocal commentstring=#%s


### PR DESCRIPTION
Hello,

I just saw the plugin about half an hour ago and downloaded it to check the commenting/uncommenting lines in .gitignore files with vim-commentary plugin. But it didn't work. So I fixed that by putting the line

``` vim
setlocal commentstring=#%s
```

to the syntax file. My guess is that with `'commentstring'` option set correctly you can remove `plugin/gitignore.vim` file and tComment plugin will still work as expected. But I don't have tComment installed, so I didn't touch the file.

I also noticed some very minor issues with ftdetect plugin and one of snippets and fixed them.

Thanks for the `gitignore.vim`!
